### PR TITLE
[platform][sand] Update timer solution

### DIFF
--- a/lib/smc/smc_x86.c
+++ b/lib/smc/smc_x86.c
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <lib/sm.h>
+#include <lib/sm/smcall.h>
+#include <lk/init.h>
+#include <lib/sm/sm_err.h>
+#include <arch/local_apic.h>
+#include <platform/sand_defs.h>
+
+/* Max entity defined as SMC_NUM_ENTITIES(64) */
+#define SMC_ENTITY_SMC_X86 63 /* Used for customized SMC calls */
+#define SMC_SC_LK_TIMER SMC_STDCALL_NR(SMC_ENTITY_SMC_X86, 0)
+
+static long self_ipi_trigger_timer_intr(void)
+{
+    /*
+     * Send self IPI needs Local APIC support.
+     * Since issue EOI also needs Local APIC support, share same
+     * macro on send self IPI and issue EOI.
+     */
+#if ISSUE_EOI
+    send_self_ipi(INT_PIT);
+#else
+    __asm__ __volatile__ ("int $0x31");
+#endif
+
+    return 0;
+}
+
+static long smc_x86_stdcall(smc32_args_t *args)
+{
+    switch (args->smc_nr) {
+        case SMC_SC_LK_TIMER:
+            return self_ipi_trigger_timer_intr();
+        default:
+            return SM_ERR_UNDEFINED_SMC;
+    }
+
+    return 0;
+}
+
+static smc32_entity_t smc_x86_entity= {
+    .stdcall_handler = smc_x86_stdcall,
+};
+
+static void smc_x86_init(uint level)
+{
+    int err;
+
+    err = sm_register_entity(SMC_ENTITY_SMC_X86, &smc_x86_entity);
+    if (err) {
+        printf("Failed to register self IPI: %d\n", err);
+    }
+}
+LK_INIT_HOOK(x86smc, smc_x86_init, LK_INIT_LEVEL_APPS);

--- a/rules.mk
+++ b/rules.mk
@@ -42,7 +42,8 @@ MODULE_SRCS += \
 	$(LOCAL_DIR)/debug.c \
 	$(LOCAL_DIR)/entry.c \
 	$(LOCAL_DIR)/vmcall.c \
-	$(LOCAL_DIR)/lib/pci/pci_config.c
+	$(LOCAL_DIR)/lib/pci/pci_config.c \
+	$(LOCAL_DIR)/lib/smc/smc_x86.c
 
 ifeq ($(WITH_SMP),1)
 MODULE_SRCS += \

--- a/timer.c
+++ b/timer.c
@@ -49,21 +49,6 @@ static uint64_t timer_delta_time; /* in ms */
 static platform_timer_callback t_callback;
 static void *callback_arg;
 
-#define TRUSTY_VMCALL_TIMER 0x74727503 /* "tru" is 0x747275 */
-typedef enum {
-    TIMER_MODE_PERIOD,
-    TIMER_MODE_ONESHOT,
-    TIMER_MODE_STOPPED,
-} vmx_timer_mode_t;
-
-static inline void make_timer_vmcall(vmx_timer_mode_t mode, uint64_t interval_in_ms)
-{
-    __asm__ __volatile__(
-            "vmcall"
-            ::"a"(TRUSTY_VMCALL_TIMER), "b"(mode), "c"(interval_in_ms)
-            );
-}
-
 lk_time_t current_time(void)
 {
     uint64_t val;


### PR DESCRIPTION
In previous proxy timer solution, when there is a timer interrupt
delivered to LK, vmm needs to injects timer interrupt to LK.
In order to decouple this binding of LK and vmm, new customized SMC call
introduced. When there is a request to trigger a timer interrupt in LK
side, invokes customized SMC from Android side, the corresponding SMC
handler in LK triggers timer interrupt itself, either by sending self IPI
(if Local APIC support) or using 'int' instruction (if Local APIC unsupported).

Change-Id: Idd6411b891fd8b8051f8ce38d16300e9e78c424d
Signed-off-by: Zhong,Fangjian <fangjian.zhong@intel.com>